### PR TITLE
Migliora questionario con nuova categoria

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,5 @@ Testcoaching/
 ```
 
 > **Nota:** Aggiorna l’indice se aggiungi o rimuovi file importanti.
+
+Il file `data/questions.json` contiene 24 domande suddivise in sei categorie: leadership, intelligenza_emotiva, ottimismo, soft_skills, hard_skills e problem_solving.

--- a/data/questions.json
+++ b/data/questions.json
@@ -118,5 +118,30 @@
     "text": "Ti tieni aggiornato sulle novità del tuo settore e migliori continuamente le tue competenze?",
     "category": "hard_skills",
     "weight": 1
+  },
+  {
+    "id": 21,
+    "text": "Quando devi affrontare un problema complesso, analizzi sistematicamente tutte le possibili soluzioni?",
+    "category": "problem_solving",
+    "weight": 1
+  },
+  {
+    "id": 22,
+    "text": "Se una strategia non funziona, sei capace di cambiarla velocemente senza scoraggiarti?",
+    "category": "problem_solving",
+    "weight": 1
+  },
+  {
+    "id": 23,
+    "text": "Ti piace scomporre i problemi in parti più piccole per risolverli più facilmente?",
+    "category": "problem_solving",
+    "weight": 1
+  },
+  {
+    "id": 24,
+    "text": "Quando incontri un ostacolo inatteso, riesci a trovare alternative creative per superarlo?",
+    "category": "problem_solving",
+    "weight": 1
   }
 ]
+

--- a/run_test.py
+++ b/run_test.py
@@ -4,7 +4,7 @@ from services.analysis import generate_radar_chart, save_summary
 
 def ask_questions(questions):
     """
-    Mostra le 20 domande e raccoglie le risposte dell'utente (scala 1-5).
+    Mostra le 24 domande e raccoglie le risposte dell'utente (scala 1-5).
     """
     answers = {}
     print("Rispondi alle seguenti domande (1 = per niente d'accordo, 5 = totalmente d'accordo):\n")


### PR DESCRIPTION
## Summary
- ampliato `questions.json` con 4 nuove domande di problem solving
- aggiornato commento in `run_test.py`
- indicata in README la presenza di 24 domande e 6 categorie

## Testing
- `python -m py_compile services/questions.py services/analysis.py services/análisis.py run_test.py`
- `python - <<'EOF'
from services.questions import load_questions
qs = load_questions()
print('count', len(qs))
from collections import Counter
print('category counts:', Counter(q['category'] for q in qs))
EOF`

------
https://chatgpt.com/codex/tasks/task_e_68863326a98c8331b4a3fa40ab4fa41a