### PR TITLE
Add HTML questionnaire export script

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Testcoaching/
 │   (qui saranno salvati il report e il grafico)
 │
 ├── run_test.py
+├── generate_html.py
 └── README.md
 
 
@@ -28,3 +29,11 @@ Testcoaching/
 > **Nota:** Aggiorna l’indice se aggiungi o rimuovi file importanti.
 
 Il file `data/questions.json` contiene 100 domande suddivise in sei categorie: leadership, intelligenza_emotiva, ottimismo, soft_skills, hard_skills e problem_solving.
+
+Per ottenere una versione HTML del questionario esegui:
+
+```bash
+python generate_html.py
+```
+
+Il file risultante `docs/test.html` potrà essere aperto con qualsiasi browser e stampato o distribuito.

--- a/generate_html.py
+++ b/generate_html.py
@@ -1,0 +1,44 @@
+import os
+from services.questions import load_questions
+
+OUTPUT_HTML = "docs/test.html"
+
+HTML_HEADER = """<!DOCTYPE html>
+<html lang='it'>
+<head>
+    <meta charset='utf-8'>
+    <title>Questionario di Coaching</title>
+    <style>
+        body { font-family: Arial, sans-serif; }
+        .question { margin-bottom: 1em; }
+    </style>
+</head>
+<body>
+<h1>Questionario completo</h1>
+<form>
+"""
+
+HTML_FOOTER = """
+<button type='submit'>Invia</button>
+</form>
+</body>
+</html>
+"""
+
+def generate_html(questions):
+    parts = [HTML_HEADER]
+    for q in questions:
+        parts.append(f"<div class='question'>\n<p>{q['id']}) {q['text']}</p>")
+        for i in range(1, 6):
+            parts.append(f"<label><input type='radio' name='q{q['id']}' value='{i}'> {i}</label>")
+        parts.append("</div>\n<hr>")
+    parts.append(HTML_FOOTER)
+    return "\n".join(parts)
+
+if __name__ == "__main__":
+    os.makedirs('docs', exist_ok=True)
+    questions = load_questions()
+    html = generate_html(questions)
+    with open(OUTPUT_HTML, 'w', encoding='utf-8') as f:
+        f.write(html)
+    print(f"HTML generato in {OUTPUT_HTML}")


### PR DESCRIPTION
## Summary
- add `generate_html.py` to create an HTML version of the questionnaire
- document the new script in `README.md`

## Testing
- `python -m py_compile run_test.py services/analysis.py services/questions.py generate_html.py`
- `python -m py_compile "services/análisis.py"`


------
https://chatgpt.com/codex/tasks/task_e_68864015724c8331bc0a3d136ef7822f